### PR TITLE
feat(vscode): add askSelection context command

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -194,6 +194,12 @@
         "group": "Continue"
       },
       {
+        "command": "continue.askSelection",
+        "category": "Continue",
+        "title": "Preguntar a Continue sobre la selección",
+        "group": "Continue"
+      },
+      {
         "command": "continue.debugTerminal",
         "category": "Continue",
         "title": "Debug Terminal",
@@ -510,6 +516,11 @@
         }
       ],
       "editor/context": [
+        {
+          "command": "continue.askSelection",
+          "group": "0_acontinue",
+          "when": "editorHasSelection"
+        },
         {
           "submenu": "continue.continueSubMenu",
           "group": "0_acontinue"

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -330,6 +330,11 @@ const getCommandsMap: (
         void addHighlightedCodeToContext(sidebar.webviewProtocol);
       }
     },
+    "continue.askSelection": async () => {
+      focusGUI();
+      await addHighlightedCodeToContext(sidebar.webviewProtocol);
+      void sidebar.webviewProtocol.request("focusContinueInputWithoutClear");
+    },
     // QuickEditShowParams are passed from CodeLens, temp fix
     // until we update to new params specific to Edit
     "continue.focusEdit": async (args?: QuickEditShowParams) => {


### PR DESCRIPTION
## Summary
- add `continue.askSelection` command and context menu entry to ask Continue about selected text
- implement command to focus sidebar, attach selection, and focus input

## Testing
- `npm run package` *(fails: Cannot find module '@continuedev/config-types')*
- `npm run tsc` *(fails: Cannot find module '@continuedev/fetch')*

------
https://chatgpt.com/codex/tasks/task_e_689e9faef9ec83298f7253329c0b03c6